### PR TITLE
Performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+problems

--- a/golfscript.rb
+++ b/golfscript.rb
@@ -195,7 +195,7 @@ class Gstring < Garray
 	def initialize(a)
 		@val=case a
 			when NilClass then []
-			when String then a.bytes
+			when String then a.unpack('C*')
 			when Array then a
 			when Garray then a.flatten.val
 		end

--- a/test_suite.py
+++ b/test_suite.py
@@ -12,11 +12,15 @@ if __name__ == "__main__":
     except FileNotFoundError:
         print("Download https://drive.google.com/file/d/1kvFxYh2fo3bHfVj1OKKLX8YzuxswHvYg/view?usp=sharing and extract it to a directory named 'problems' in this folder.")
         sys.exit(1)
+
+    passes = fails = 0
     for prob in sorted(problems, key=lambda x: x.name):
         # Luck / weird problems
-        if prob.name in ["123", "123 Reloaded", "Error", "Helloworld", "Inverse Quine", "Not Quine", "Quine", "Timeout"]: continue
-        # Ruby version stuff
+        if prob.name in ["123", "123 Reloaded", "Error", "Inverse Quine", "Not Quine", "Palindromic Quine", "Quine", "Timeout"]: continue
+        # Ruby version / float / rational trickery
         if prob.name in ["area of triangle", "0_5 broken keyboard", "Cancel fractions", "Equal Temperament", "MIDI note number to frequency", "Numloop"]: continue
+        # Sisyphus's dump was unluckily case-insensitive, so these have wrong answers mixed in:
+        if prob.name.lower() in ["helloworld", "christmas tree", "multiplication table"]: continue
 
         if sys.argv[1:] and prob.name < sys.argv[1]: continue
         if not prob.is_dir(): continue
@@ -44,13 +48,13 @@ if __name__ == "__main__":
                 if b'#{' in soln_string: continue
                 pi = problem["input"].encode("utf-8").replace(b"\r\n", b"\n")
                 po = problem["output"].encode("utf-8").replace(b"\r\n", b"\n")
-                try:
-                    #print(soln.path)
-                    soln_output = subprocess.run(["ruby", "--encoding", "ASCII-8BIT", "golfscript.rb", soln.path], input=pi, stdout=subprocess.PIPE).stdout
-                    if soln_output.rstrip() == po.rstrip():
-                        print(soln.path, "\x1b[32mOK\x1b[0m")
-                    else:
-                        print(soln.path, "\x1b[31mFAIL\x1b[0m")
-                        print(soln_output[:100], po[:100])
-                except subprocess.CalledProcessError:
-                    print(soln.path, "CRASH")
+                soln_output = subprocess.run(["ruby", "--encoding", "ASCII-8BIT", "golfscript.rb", soln.path], input=pi, stdout=subprocess.PIPE).stdout
+                if soln_output.rstrip() == po.rstrip():
+                    print("\x1b[32mPASS\x1b[0m", soln.path)
+                    passes += 1
+                else:
+                    print("\x1b[31mFAIL\x1b[0m", soln.path)
+                    print(soln_output[:100], po[:100])
+                    fails += 1
+    print(f"{passes} passes, {fails} fails")
+

--- a/test_suite.py
+++ b/test_suite.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 
 min_date = 1199142000 # january 1, 2008
+compact = False
 
 if __name__ == "__main__":
     try:
@@ -14,11 +15,12 @@ if __name__ == "__main__":
         sys.exit(1)
 
     passes = fails = 0
+    last_pass = False
     for prob in sorted(problems, key=lambda x: x.name):
         # Luck / weird problems
         if prob.name in ["123", "123 Reloaded", "Error", "Inverse Quine", "Not Quine", "Palindromic Quine", "Quine", "Timeout"]: continue
         # Ruby version / float / rational trickery
-        if prob.name in ["area of triangle", "0_5 broken keyboard", "Cancel fractions", "Equal Temperament", "MIDI note number to frequency", "Numloop"]: continue
+        if prob.name in ["area of triangle", "Concentric Circles", "0_5 broken keyboard", "Cancel fractions", "Equal Temperament", "MIDI note number to frequency", "Numloop"]: continue
         # Sisyphus's dump was unluckily case-insensitive, so these have wrong answers mixed in:
         if prob.name.lower() in ["helloworld", "christmas tree", "multiplication table"]: continue
 
@@ -36,25 +38,36 @@ if __name__ == "__main__":
                 problem = json.loads(fp.read())
         except json.decoder.JSONDecodeError:
             continue
-        
         for soln in os.scandir(os.path.join(prob, "gs")):
             date = int(soln.name.split(".")[-2])
             if date < min_date: continue
+            # I'm sorry! https://github.com/shinh/ags/issues/4
             if 1531576304 - 10000 < date < 1531576304 + 10000 and soln.name.startswith("lynn"): continue
             if problem["output"] and 1 <= os.path.getsize(soln.path):
                 soln_string = open(soln.path, 'rb').read()
+                try: soln_string.decode("utf-8")
+                except: continue
+                if b'\0' in soln_string: continue
                 if b'rand' in soln_string: continue
                 if b'../s/' in soln_string: continue
                 if b'#{' in soln_string: continue
                 pi = problem["input"].encode("utf-8").replace(b"\r\n", b"\n")
                 po = problem["output"].encode("utf-8").replace(b"\r\n", b"\n")
-                soln_output = subprocess.run(["ruby", "--encoding", "ASCII-8BIT", "golfscript.rb", soln.path], input=pi, stdout=subprocess.PIPE).stdout
-                if soln_output.rstrip() == po.rstrip():
-                    print("\x1b[32mPASS\x1b[0m", soln.path)
-                    passes += 1
-                else:
-                    print("\x1b[31mFAIL\x1b[0m", soln.path)
-                    print(soln_output[:100], po[:100])
+                try:
+                    soln_output = subprocess.run(["ruby", "--encoding", "ASCII-8BIT", "golfscript.rb", soln.path], input=pi, stdout=subprocess.PIPE, timeout=5).stdout
+                    if soln_output.replace(b"\r\n", b"\n").rstrip() == po.rstrip():
+                        print(("\x1b[1A\x1b[K"*compact*last_pass) + "\x1b[32mPASS\x1b[0m", soln.path)
+                        last_pass = True
+                        passes += 1
+                    else:
+                        print("\x1b[31mFAIL\x1b[0m", soln.path)
+                        print(soln_output[:100], po[:100])
+                        last_pass = False
+                        fails += 1
+                except subprocess.TimeoutExpired:
+                    print("\x1b[33mSLOW\x1b[0m", soln.path)
+                    last_pass = False
                     fails += 1
+
     print(f"{passes} passes, {fails} fails")
 

--- a/test_suite.py
+++ b/test_suite.py
@@ -1,0 +1,56 @@
+import json
+import requests
+import os
+import subprocess
+import sys
+
+min_date = 1199142000 # january 1, 2008
+
+if __name__ == "__main__":
+    try:
+        problems = os.scandir("problems")
+    except FileNotFoundError:
+        print("Download https://drive.google.com/file/d/1kvFxYh2fo3bHfVj1OKKLX8YzuxswHvYg/view?usp=sharing and extract it to a directory named 'problems' in this folder.")
+        sys.exit(1)
+    for prob in sorted(problems, key=lambda x: x.name):
+        # Luck / weird problems
+        if prob.name in ["123", "123 Reloaded", "Error", "Helloworld", "Inverse Quine", "Not Quine", "Quine", "Timeout"]: continue
+        # Ruby version stuff
+        if prob.name in ["area of triangle", "0_5 broken keyboard", "Cancel fractions", "Equal Temperament", "MIDI note number to frequency", "Numloop"]: continue
+
+        if sys.argv[1:] and prob.name < sys.argv[1]: continue
+        if not prob.is_dir(): continue
+        problem_path = os.path.join(prob, "problem.json")
+        if not os.path.isdir(os.path.join(prob, "gs")): continue
+        
+        if not os.path.isfile(problem_path):
+            print("Fetching " + prob.name)
+            response = requests.get("http://golf.shinh.org/jsonp.rb?" + prob.name.replace(" ", "+"))
+            with open(problem_path, 'wb') as fp: fp.write(response.content)
+        try:
+            with open(problem_path, 'rb') as fp:
+                problem = json.loads(fp.read())
+        except json.decoder.JSONDecodeError:
+            continue
+        
+        for soln in os.scandir(os.path.join(prob, "gs")):
+            date = int(soln.name.split(".")[-2])
+            if date < min_date: continue
+            if 1531576304 - 10000 < date < 1531576304 + 10000 and soln.name.startswith("lynn"): continue
+            if problem["output"] and 1 <= os.path.getsize(soln.path):
+                soln_string = open(soln.path, 'rb').read()
+                if b'rand' in soln_string: continue
+                if b'../s/' in soln_string: continue
+                if b'#{' in soln_string: continue
+                pi = problem["input"].encode("utf-8").replace(b"\r\n", b"\n")
+                po = problem["output"].encode("utf-8").replace(b"\r\n", b"\n")
+                try:
+                    #print(soln.path)
+                    soln_output = subprocess.run(["ruby", "--encoding", "ASCII-8BIT", "golfscript.rb", soln.path], input=pi, stdout=subprocess.PIPE).stdout
+                    if soln_output.rstrip() == po.rstrip():
+                        print(soln.path, "\x1b[32mOK\x1b[0m")
+                    else:
+                        print(soln.path, "\x1b[31mFAIL\x1b[0m")
+                        print(soln_output[:100], po[:100])
+                except subprocess.CalledProcessError:
+                    print(soln.path, "CRASH")


### PR DESCRIPTION
As mentioned in my email, this makes `array string *` and `array.to_gs` not quadratic.

I tested the resulting change on 1906 GolfScript solutions that Sisyphus in the code.golf Discord had scraped from http://golf.shinh.org. I wondered if I could make this test suite run a little faster so I used ruby-prof to benchmark the execution…

It turns out that a lot of time is spent on `Gint.new` and `Gint.val`. So I had the idea to get rid of `Gint` and instead work with plain `Numeric` everywhere. This works and makes all programs about 25% faster, but this PR much more complicated 🙂 

Feeling confident about having an exhaustive test suite I made some other performance improvements here and there.

BTW, to my surprise, the interpreter is supported just fine by Ruby 3 even though it was written for 1.9! I only have to run `ruby --encoding ASCII-8BIT golfscript.rb` so that it doesn't complain about non-UTF-8 strings.